### PR TITLE
Fixes #78 Do not acquire lock and skip migration if there is no change set item to be executed

### DIFF
--- a/changock-runner/changock-runner-core/src/test/java/io/changock/runner/core/changelogs/skipmigration/alreadyexecuted/ChangeLogAlreadyExecuted.java
+++ b/changock-runner/changock-runner-core/src/test/java/io/changock/runner/core/changelogs/skipmigration/alreadyexecuted/ChangeLogAlreadyExecuted.java
@@ -1,0 +1,19 @@
+package io.changock.runner.core.changelogs.skipmigration.alreadyexecuted;
+
+import io.changock.migration.api.annotations.ChangeLog;
+import io.changock.migration.api.annotations.ChangeSet;
+import io.changock.runner.core.util.DummyDependencyClass;
+
+@ChangeLog
+public class ChangeLogAlreadyExecuted {
+
+  @ChangeSet(author = "executor", id = "alreadyExecuted", order = "1")
+  public void alreadyExecuted(DummyDependencyClass dependency) {
+    throw new RuntimeException("This method should not be executed, as it's supposed to be already executed");
+  }
+
+  @ChangeSet(author = "executor", id = "alreadyExecuted2", order = "2")
+  public void alreadyExecuted2(DummyDependencyClass dependency) {
+    throw new RuntimeException("This method should not be executed, as it's supposed to be already executed");
+  }
+}

--- a/changock-runner/changock-runner-core/src/test/java/io/changock/runner/core/changelogs/skipmigration/runalways/ChangeLogAlreadyExecutedRunAlways.java
+++ b/changock-runner/changock-runner-core/src/test/java/io/changock/runner/core/changelogs/skipmigration/runalways/ChangeLogAlreadyExecutedRunAlways.java
@@ -1,0 +1,24 @@
+package io.changock.runner.core.changelogs.skipmigration.runalways;
+
+import io.changock.migration.api.annotations.ChangeLog;
+import io.changock.migration.api.annotations.ChangeSet;
+import io.changock.runner.core.util.DummyDependencyClass;
+
+@ChangeLog
+public class ChangeLogAlreadyExecutedRunAlways {
+
+  @ChangeSet(author = "executor", id = "alreadyExecuted", order = "1")
+  public void alreadyExecuted(DummyDependencyClass dependency) {
+    throw new RuntimeException("This method should not be executed, as it's supposed to be already executed");
+  }
+
+  @ChangeSet(author = "executor", id = "alreadyExecuted2", order = "2")
+  public void alreadyExecuted2(DummyDependencyClass dependency) {
+    throw new RuntimeException("This method should not be executed, as it's supposed to be already executed");
+  }
+
+  @ChangeSet(author = "executor", id = "alreadyExecutedRunAlways", order = "3", runAlways = true)
+  public void alreadyExecutedRunAlways(DummyDependencyClass dependency) {
+    // do nothing
+  }
+}

--- a/changock-runner/changock-runner-core/src/test/java/io/changock/runner/core/changelogs/skipmigration/withnochangeset/ChangeLogWithNoChangeSet.java
+++ b/changock-runner/changock-runner-core/src/test/java/io/changock/runner/core/changelogs/skipmigration/withnochangeset/ChangeLogWithNoChangeSet.java
@@ -1,0 +1,11 @@
+package io.changock.runner.core.changelogs.skipmigration.withnochangeset;
+
+import io.changock.migration.api.annotations.ChangeLog;
+
+@ChangeLog(order = "1")
+public class ChangeLogWithNoChangeSet {
+
+  public void method() {
+  }
+
+}

--- a/changock-runner/spring-runners/changock-spring-v5-runner/src/test/java/io/cloudyrock/changock/runner/spring/v5/SpringChangockApplicationRunnerTest.java
+++ b/changock-runner/spring-runners/changock-spring-v5-runner/src/test/java/io/cloudyrock/changock/runner/spring/v5/SpringChangockApplicationRunnerTest.java
@@ -32,10 +32,7 @@ import org.mockito.internal.verification.Times;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -94,11 +91,12 @@ public class SpringChangockApplicationRunnerTest {
 
     // then
     ArgumentCaptor<String> changeSetIdCaptor = ArgumentCaptor.forClass(String.class);
-    verify(changeEntryService, new Times(3)).isAlreadyExecuted(changeSetIdCaptor.capture(), anyString());
+    int wantedNumberOfInvocations = 3 + 1; // 3 -> Number of changes, 1 -> Pre migration check
+    verify(changeEntryService, new Times(wantedNumberOfInvocations)).isAlreadyExecuted(changeSetIdCaptor.capture(), anyString());
 
     List<String> changeSetIdList = changeSetIdCaptor.getAllValues();
-    assertEquals(3, changeSetIdList.size());
-    assertTrue(changeSetIdList.contains("testWithProfileIncluded1"));
+    assertEquals(wantedNumberOfInvocations, changeSetIdList.size());
+    assertEquals(2, Collections.frequency(changeSetIdList, "testWithProfileIncluded1"));
     assertTrue(changeSetIdList.contains("testWithProfileIncluded2"));
     assertTrue(changeSetIdList.contains("testWithProfileIncluded1OrProfileINotIncluded"));
   }

--- a/changock-runner/spring-runners/changock-spring-v5-runner/src/test/java/io/cloudyrock/changock/runner/spring/v5/SpringChangockInitializingBeanRunnerTest.java
+++ b/changock-runner/spring-runners/changock-spring-v5-runner/src/test/java/io/cloudyrock/changock/runner/spring/v5/SpringChangockInitializingBeanRunnerTest.java
@@ -25,6 +25,7 @@ import org.mockito.internal.verification.Times;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -87,11 +88,12 @@ public class SpringChangockInitializingBeanRunnerTest {
 
     // then
     ArgumentCaptor<String> changeSetIdCaptor = ArgumentCaptor.forClass(String.class);
-    verify(changeEntryService, new Times(3)).isAlreadyExecuted(changeSetIdCaptor.capture(), anyString());
+    int wantedNumberOfInvocations = 3 + 1; // 3 -> Number of changes, 1 -> Pre migration check
+    verify(changeEntryService, new Times(wantedNumberOfInvocations)).isAlreadyExecuted(changeSetIdCaptor.capture(), anyString());
 
     List<String> changeSetIdList = changeSetIdCaptor.getAllValues();
-    assertEquals(3, changeSetIdList.size());
-    assertTrue(changeSetIdList.contains("testWithProfileIncluded1"));
+    assertEquals(wantedNumberOfInvocations, changeSetIdList.size());
+    assertEquals(2, Collections.frequency(changeSetIdList, "testWithProfileIncluded1"));
     assertTrue(changeSetIdList.contains("testWithProfileIncluded2"));
     assertTrue(changeSetIdList.contains("testWithProfileIncluded1OrProfileINotIncluded"));
   }


### PR DESCRIPTION
Details can be found in related issue #78 